### PR TITLE
Dropdown table bottom button fixed

### DIFF
--- a/components/common/Table/DropdownTable/DropdownTable.jsx
+++ b/components/common/Table/DropdownTable/DropdownTable.jsx
@@ -96,13 +96,15 @@ const DropdownTable = ({
           </Typography>
         )}
       </CardContent>
-      <CardActions
-        sx={{ padding: '24px 20px 22px', borderTop: '1px solid #EDEFF5' }}
-      >
-        <Button variant="contained" size="medium" disableElevation fullWidth>
-          Compare Sites
-        </Button>
-      </CardActions>
+      {tableDataBase && Object.keys(tableDataBase[0])[1] === 'sites' && (
+        <CardActions
+          sx={{ padding: '24px 20px 22px', borderTop: '1px solid #EDEFF5' }}
+        >
+          <Button variant="contained" size="medium" disableElevation fullWidth>
+            Compare Sites
+          </Button>
+        </CardActions>
+      )}
     </Card>
   )
 }

--- a/styles/muiCustomTheme.jsx
+++ b/styles/muiCustomTheme.jsx
@@ -156,5 +156,14 @@ export const muiCustomTheme = createTheme({
         },
       },
     },
+    MuiCardContent: {
+      styleOverrides: {
+        root: {
+          '&:last-child': {
+            paddingBottom: 0,
+          },
+        },
+      },
+    },
   },
 })


### PR DESCRIPTION
- `Compare Sites` button on the bottom of the `tech` and `practice` tables have been removed.
- Retained on `site` table